### PR TITLE
Remove duplicated code due to an incorrect merge

### DIFF
--- a/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
+++ b/Source/RunActivity/Viewer3D/Debugging/DebugViewerForm.cs
@@ -1556,20 +1556,6 @@ namespace Orts.Viewer3D.Debugging
 			  // in the interval between this list is shown and the option is selected by dispatcher
 		  }
 
-
-		  if (boxSetSignal.Items.Count == 5)
-			  boxSetSignal.Items.RemoveAt(4);
-
-		  if (signalPickedItem.Signal.enabledTrain != null && signalPickedItem.Signal.CallOnEnabled)
-		  {
-			  if (signalPickedItem.Signal.enabledTrain.Train.AllowedCallOnSignal != signalPickedItem.Signal)
-			  boxSetSignal.Items.Add("Enable call on");
-			  /*else
-				  boxSetSignal.Items.Add("Disable call on");*/
-			  // To disable Call On signal must be manually set to stop, to avoid signal state change
-			  // in the interval between this list is shown and the option is selected by dispatcher
-		  }
-
 		  boxSetSignal.Location = new System.Drawing.Point(LastCursorPosition.X + 2, y);
 		  boxSetSignal.Enabled = true;
 		  boxSetSignal.Focus();


### PR DESCRIPTION
The code for call-on through the dispatcher window was lost in the official repository, so I had to reintroduce the PR. However, this has lead to the PR being introduced twice into the NewYear version. I hope this will solve it.