### PR TITLE
Correct bug affecting size of the ETCS DMI in some resolutions

### DIFF
--- a/Source/RunActivity/RunActivity.csproj
+++ b/Source/RunActivity/RunActivity.csproj
@@ -646,9 +646,6 @@
     <Content Include="Content\ETCS\SE_04.bmp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Content\ETCS\ETCS_DMI_symbols_credit.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="Content\LightConeShader.fx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Source/RunActivity/RunActivity.csproj
+++ b/Source/RunActivity/RunActivity.csproj
@@ -235,6 +235,9 @@
     <Content Include="Content\DriverMachineInterfaceShader.fx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Content\ETCS\ETCS_DMI_symbols_credit.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Content\ETCS\mipmap-2\NA_01.bmp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -1199,7 +1199,7 @@ namespace Orts.Viewer3D.RollingStock
                         {
                             if (screen.ControlType == CABViewControlTypes.ORTS_ETCS)
                             {
-                                DriverMachineInterfaceRenderer cvr = new DriverMachineInterfaceRenderer(viewer, car, screen, _Shader);
+                                var cvr = new DriverMachineInterfaceRenderer(viewer, car, screen, _Shader);
                                 cvr.SortIndex = controlSortIndex;
                                 CabViewControlRenderersList[i].Add(cvr);
                                 if (!ControlMap.ContainsKey(key)) ControlMap.Add(key, cvr);
@@ -1312,7 +1312,7 @@ namespace Orts.Viewer3D.RollingStock
                 {
                     if (screen.ControlType == CABViewControlTypes.ORTS_ETCS)
                     {
-                        DriverMachineInterfaceRenderer cvr = new DriverMachineInterfaceRenderer(viewer, car, screen, _Shader);
+                        var cvr = new DriverMachineInterfaceRenderer(viewer, car, screen, _Shader);
                         cvr.SortIndex = controlSortIndex;
                         CabViewControlRenderersList[i].Add(cvr);
                         if (!ControlMap.ContainsKey(key)) ControlMap.Add(key, cvr);

--- a/Source/RunActivity/Viewer3D/RollingStock/SubSystems/ETCS/DriverMachineInterface.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/SubSystems/ETCS/DriverMachineInterface.cs
@@ -90,8 +90,8 @@ namespace Orts.Viewer3D.RollingStock.Subsystems.ETCS
             Viewer = viewer;
             Locomotive = locomotive;
             Scale = Math.Min(width / Width, height / Height);
-            /*if (Scale < 0.5) */MipMapScale = 2;
-            //else MipMapScale = 1;
+            if (Scale < 0.5) MipMapScale = 2;
+            else MipMapScale = 1;
             GaugeOnly = control is CVCDigital;
 
             Shader = new DriverMachineInterfaceShader(Viewer.GraphicsDevice);
@@ -141,8 +141,8 @@ namespace Orts.Viewer3D.RollingStock.Subsystems.ETCS
             if (Math.Abs(1f - PrevScale / Scale) > 0.1f)
             {
                 PrevScale = Scale;
-                /*if (Scale < 0.5) */MipMapScale = 2;
-                /*else MipMapScale = 1;*/
+                if (Scale < 0.5) MipMapScale = 2;
+                else MipMapScale = 1;
                 foreach (var area in Windows)
                 {
                     area.ScaleChanged();
@@ -749,16 +749,24 @@ namespace Orts.Viewer3D.RollingStock.Subsystems.ETCS
         {
             Position.X = (float)Control.PositionX;
             Position.Y = (float)Control.PositionY;
-            DMI = new DriverMachineInterface((int)Control.Width, (int)Control.Height, locomotive, viewer, control);
+            if ((int)Control.Height == 102 && (int)Control.Width == 136)
+            {
+                // Hack for ETR400 cab, which was built with a bugged size calculation of digital displays
+                Control.Height *= 0.75f;
+                Control.Width *= 0.75f;
+            }
+            DMI = new DriverMachineInterface((int)Control.Height, (int)Control.Width, locomotive, viewer, control);
         }
 
         public override void PrepareFrame(RenderFrame frame, ElapsedTime elapsedTime)
         {
             base.PrepareFrame(frame, elapsedTime);
-            DrawPosition.X = (int)(Position.X * Viewer.CabWidthPixels / 640) - Viewer.CabXOffsetPixels + Viewer.CabXLetterboxPixels;
-            DrawPosition.Y = (int)(Position.Y * Viewer.CabHeightPixels / 480) + Viewer.CabYOffsetPixels + Viewer.CabYLetterboxPixels;
-            DrawPosition.Width = (int)(Control.Width * Viewer.DisplaySize.X / 640);
-            DrawPosition.Height = (int)(Control.Height * Viewer.DisplaySize.Y / 480);
+            var xScale = Viewer.CabWidthPixels / 640f;
+            var yScale = Viewer.CabHeightPixels / 480f;
+            DrawPosition.X = (int)(Position.X * xScale) - Viewer.CabXOffsetPixels + Viewer.CabXLetterboxPixels;
+            DrawPosition.Y = (int)(Position.Y * yScale) + Viewer.CabYOffsetPixels + Viewer.CabYLetterboxPixels;
+            DrawPosition.Width = (int)(Control.Width * xScale);
+            DrawPosition.Height = (int)(Control.Height * yScale);
             if (Zoomed)
             {
                 DrawPosition.Width = 640;


### PR DESCRIPTION
I have tested this patch with two trains (ETR400 and Talgo 250) and the DMI is correctly displayed in letterbox, windowed and full screen modes, so I hope no more problems will appear with this.