### PR TITLE
Added some behavior

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSLocomotive.cs
@@ -3028,6 +3028,16 @@ namespace Orts.Simulation.RollingStocks
         {
             if (CruiseControl != null && target != null)
             {
+                if (CruiseControl.DisableCruiseControlOnThrottleAndZeroSpeed && AbsSpeedMpS == 0 && CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto)
+                {
+                    CruiseControl.SetSpeed(0);
+                    CruiseControl.SpeedRegMode = CruiseControl.SpeedRegulatorMode.Manual;
+                }
+                if (CruiseControl.DisableCruiseControlOnThrottleAndZeroForce && CruiseControl.SelectedMaxAccelerationPercent == 0 && CruiseControl.SelectedMaxAccelerationStep == 0 && CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto)
+                {
+                    CruiseControl.SetSpeed(0);
+                    CruiseControl.SpeedRegMode = CruiseControl.SpeedRegulatorMode.Manual;
+                }
                 if (CruiseControl.SpeedRegMode == CruiseControl.SpeedRegulatorMode.Auto && CruiseControl.UseThrottleAsSpeedSelector)
                 {
                     CruiseControl.SpeedRegulatorSelectedSpeedStartIncrease();

--- a/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/CruiseControl.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/SubSystems/CruiseControl.cs
@@ -110,6 +110,8 @@ namespace Orts.Simulation.RollingStocks.SubSystems
         public float SafeSpeedForAutomaticOperationMpS = 0;
         protected float SpeedSelectorStepTimeSeconds = 0;
         protected float elapsedTime = 0;
+        public bool DisableCruiseControlOnThrottleAndZeroSpeed = false;
+        public bool DisableCruiseControlOnThrottleAndZeroForce = false;
 
         public void Parse(string lowercasetoken, STFReader stf)
         {
@@ -133,7 +135,9 @@ namespace Orts.Simulation.RollingStocks.SubSystems
                 case "engine(ortscruisecontrol(maxforcekeepselectedstepwhenmanualmodeset": MaxForceKeepSelectedStepWhenManualModeSet = stf.ReadBoolBlock(false); break;
                 case "engine(ortscruisecontrol(forceregulatorautowhennonzerospeedselected": ForceRegulatorAutoWhenNonZeroSpeedSelected = stf.ReadBoolBlock(false); break;
                 case "engine(ortscruisecontrol(continuousspeedincreasing": ContinuousSpeedIncreasing = stf.ReadBoolBlock(false); break;
-                    
+                case "engine(ortscruisecontrol(disablecruisecontrolonthrottleandzerospeed": DisableCruiseControlOnThrottleAndZeroSpeed = stf.ReadBoolBlock(false); break;
+                case "engine(ortscruisecontrol(disablecruisecontrolonthrottleandzeroforce": DisableCruiseControlOnThrottleAndZeroForce = stf.ReadBoolBlock(false); break;
+
                 case "engine(ortscruisecontrol(forcestepsthrottletable":
                     foreach (var forceStepThrottleValue in stf.ReadStringBlock("").Replace(" ", "").Split(','))
                     {


### PR DESCRIPTION
if the train is stopped and I have already set a speed and the LCA is 0%; if I move the LCM, the set speed will immediately become 0 so I can give traction with the LCM lever.
Second one. if the train is moving and I have already set a speed and the LCA is not 0%, I have to bring the LCA to 0% and then I can then move the LCM to accelerate the train or brake it. Obviously, as soon as I move the LCM the set speed becomes 0 and I will have to set it again if I want to use the LCA lever again.